### PR TITLE
adding separate squad for platform 5.0

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -18,4 +18,3 @@ mizzao:bootstrap-3
 jparker:crypto-base64
 http
 frozeman:animation-helper
-

--- a/README.md
+++ b/README.md
@@ -53,3 +53,27 @@ The following methods can be executed from the console:
 - `Meteor.call('removeAllSettings')`
 - `Meteor.call('removeAllTickets')` (if you've seeded your database with sample data)
 - `Meteor.call('removeReleases')`
+
+### Debugging server side code
+As with other languages, your browser's developer tools can be used for debugging client-side code.
+For server-side debugging, you can use [node-inspector][].
+
+Install node-inspector
+```sh
+$ npm install -g node-inspector
+```
+
+Start Meteor in debug mode
+```sh
+$ env NODE_OPTIONS='--debug' meteor
+```
+
+In a new terminal, start node-inspector
+```sh
+$ node-inspector
+```
+
+Go to the URL given to you by node-inspector. You'll see a screen that resembles Chrome's
+developer tools. Use this interface to insert breakpoints and do any other debugging.
+
+[node-inspector]: https://github.com/node-inspector/node-inspector

--- a/client/helpers.js.coffee
+++ b/client/helpers.js.coffee
@@ -175,7 +175,8 @@ closedTicketStatuses = ['Review', 'Closed', 'Deployed']
 @getSquads = ->
   [
     { name: 'Front End', activeClass: isActiveSquad('Front End') },
-    { name: 'Platform', activeClass: isActiveSquad('Platform') }
+    { name: 'Platform', activeClass: isActiveSquad('Platform') },
+    { name: 'Platform 5.0', activeClass: isActiveSquad('Platform 5.0') }
   ]
 
 @getTicketsOnHold = ->

--- a/client/home.js.coffee
+++ b/client/home.js.coffee
@@ -66,8 +66,14 @@ Template.home.events 'slide.bs.carousel': (event) ->
     pauseCarousel()
     Session.set(
       'selectedSquad',
-      if Session.get('selectedSquad') is 'Front End' then 'Platform' else 'Front End'
-    )
+      switch Session.get('selectedSquad')
+        when 'Front End'
+          'Platform'
+        when 'Platform'
+          'Platform 5.0'
+        else
+          'Front End'
+      )
 
 Tracker.autorun ->
   Session.set 'loading', true

--- a/client/stylesheets/loading_overlay.scss
+++ b/client/stylesheets/loading_overlay.scss
@@ -1,12 +1,12 @@
 .loading-overlay {
   background: image-url('charizard.gif') center center no-repeat #f3f9fb;
   height: 100%;
-  left: -14%;
+  left: -5%;
   opacity: 1;
   position: absolute;
   top: 0;
   transition: opacity 200ms;
-  width: 128%;
+  width: 110%;
   z-index: 2;
 
   .loading-text {

--- a/server/publications.js.coffee
+++ b/server/publications.js.coffee
@@ -27,6 +27,9 @@ Meteor.publish 'tickets', (selectedSquad) ->
     'Platform':
       nonBugTickets: '11476'
       bugTickets: '11474'
+    'Platform 5.0':
+      nonBugTickets: '12029'
+      bugTickets: '12028'
     withoutComponents: '11472'
 
   try

--- a/server/startup.js.coffee
+++ b/server/startup.js.coffee
@@ -7,24 +7,30 @@ Meteor.startup ->
     removeReleases: ->
       Releases.remove({})
 
-  if Releases.find().count() is 0
-    Releases.insert
-      squad: 'Front End'
-      name: 'FE4.7'
-      releaseDate: new Date('03/31/2015')
-
-    Releases.insert
-      squad: 'Platform'
-      name: 'P4.7'
-      releaseDate: new Date('03/31/2015')
-
-    Releases.insert
-      squad: 'Platform 5.0'
-      name: 'P5.0'
-      releaseDate: new Date('06/30/2015')
-
   squads = ['Front End', 'Platform', 'Platform 5.0']
   _(squads).each (squad) ->
+    release =
+      Releases.find(
+        squad: squad
+      ).fetch()
+
+    if _(release).isEmpty()
+      switch squad
+        when 'Front End'
+          name = 'FE4.7'
+          releaseDate = new Date('05/31/2015')
+        when 'Platform'
+          name = 'P4.7'
+          releaseDate = new Date('05/31/2015')
+        else
+          name = 'P5.0'
+          releaseDate = new Date('09/30/2015')
+
+      Releases.insert
+        squad: squad
+        name: name
+        releaseDate: releaseDate
+
     settings =
       Settings.find(
         squad: squad

--- a/server/startup.js.coffee
+++ b/server/startup.js.coffee
@@ -10,15 +10,20 @@ Meteor.startup ->
   if Releases.find().count() is 0
     Releases.insert
       squad: 'Front End'
-      name: '4.7'
+      name: 'FE4.7'
       releaseDate: new Date('03/31/2015')
 
     Releases.insert
       squad: 'Platform'
-      name: '5.0'
+      name: 'P4.7'
+      releaseDate: new Date('03/31/2015')
+
+    Releases.insert
+      squad: 'Platform 5.0'
+      name: 'P5.0'
       releaseDate: new Date('06/30/2015')
 
-  squads = ['Platform', 'Front End']
+  squads = ['Front End', 'Platform', 'Platform 5.0']
   _(squads).each (squad) ->
     settings =
       Settings.find(


### PR DESCRIPTION
Why: want to separate platform 4.7 tickets from platform 5.0 since they will be developed simultaneously

How: 
1) add platform 5.0 squad to client/helpers.js.coffee
2) add platform 5.0 to publications
3) add platform 5.0 startup.js 